### PR TITLE
Progress bar option on submit

### DIFF
--- a/src/SearchInput/SearchInput.xml
+++ b/src/SearchInput/SearchInput.xml
@@ -42,5 +42,20 @@
         <enumerationValue key="danger">Danger</enumerationValue>
       </enumerationValues>
     </property>
+    <property key="showProgressBar" type="boolean" required="true" defaultValue="false">
+      <caption>Show Progress Bar</caption>
+      <category>Settings</category>
+      <description></description>
+    </property>
+    <property key="isModal" type="boolean" required="true" defaultValue="false">
+      <caption>Blocking progress bar</caption>
+      <category>Settings</category>
+      <description>Used when progress bar is set to appear</description>
+    </property>
+    <property key="progressBarMessage" type="string" required="false" defaultValue="Working...">
+      <caption>Progress Bar Message</caption>
+      <category>Settings</category>
+      <description>Used when progress bar is set to appear</description>
+    </property>
   </properties>
 </widget>

--- a/src/SearchInput/widget/SearchInput.js
+++ b/src/SearchInput/widget/SearchInput.js
@@ -102,6 +102,9 @@ define([
             logger.debug(this.id + ".executeMicroFlow");
             if (mf && this._contextObj) {
                 this._clearValidations();
+		if(progress) {
+                    var pid = mx.ui.showProgress(this.progressBarMessage, this.isModal);
+                }
                 this._contextObj.set(this.targetAttribute, this.searchInputNode.value);
                 mx.data.action({
                     store: {
@@ -113,9 +116,13 @@ define([
                         guids: [this._contextObj.getGuid()]
                     },
                     callback: function() {
+			if(progress) {
+                            mx.ui.hideProgress(pid);
+                        }
                     },
                     error: dojoLang.hitch(this, function() {
                         logger.error(this.id + ".executeMicroFlow: XAS error executing microflow");
+			mx.ui.hideProgress(pid);
                     })
                 });
             }


### PR DESCRIPTION
Added options to the widget to support enabling a (modal) progress bar to be shown whenever the search is triggered. The progress bar message can also be defined.
